### PR TITLE
Add error handling for Vercel Deployment Protection

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-# Replace this URL with your own production URL after deploying to Vercel
-PRODUCTION_URL="https://nextjs-checkly-starter-template.vercel.app"

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# env
+.env*

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Great! We're all set up with testing & monitoring our Production Deployments, wh
 
 ### Running checks in CI
 
-You can run your Checkly checks right after any Vercel Preview Deployment, and then deploy your checks as monitors on Checkly. This is a powerful strategy to make sure your never ship breaking errors to Production, while at the same time surfacing any outages in your Production Deployments.
+You can run your Checkly checks right after any Vercel Preview Deployment, and then deploy your checks as monitors on Checkly. This is a powerful strategy to make sure you never ship breaking errors to Production, while at the same time surfacing any outages in your Production Deployments.
 
 This example uses GitHub Actions — check out the workflow in [`.github/workflows/checkly.yml`](/.github/workflows/checkly.yml) — but you can use any other CI platform. We have [example configs for Jenkins and GitLab CI in our docs](https://checklyhq.com/docs/cicd).
 

--- a/README.md
+++ b/README.md
@@ -40,81 +40,72 @@ By default, Vercel Preview Deployments are protected and only accessible by logg
 
 If you choose to keep Deployment Protection on, ensure:
 
-1. The **Automatically expose [System Environment Variables](https://vercel.com/docs/environment-variables/system-environment-variables)** setting (in `Project Settings > Environment Variables`) is checked; and
-2. You create a `VERCEL_AUTOMATION_BYPASS_SECRET` in `Project Settings > Deployment Protection`. Our app will automatically use this for fetching from the `/api/greetings` endpoint.
+1. The **Automatically expose [System Environment Variables](https://vercel.com/docs/environment-variables/system-environment-variables)** setting (in **Project Settings > Environment Variables**) is checked; and
+2. You create a `VERCEL_AUTOMATION_BYPASS_SECRET` in **Project Settings > Deployment Protection**. Our app will automatically use this for fetching from the `/api/greetings` endpoint.
 
 Redeploy after applying any changes to your project settings in Vercel. Each deployment will alert you of anything it's missing on the landing page.
 
----
+## Running checks
 
-3. Deploy the app to Vercel. You should now have a stable, production Vercel URL for your app similar to `https://nextjs-checkly-starter-template-checkly.vercel.app/`
-4. Copy and paste that URL into the `.env` file as the `PRODUCTION_URL` value, e.g.
+### Configuring testing & monitoring for production
 
-    ```
-    PRODUCTION_URL="YOUR VERCEL PRODUCTION URL"
-    ```
-   Now we know where to aim our production checks.
-5. Make sure you have a Checkly account. Just run this command and follow the instructions:
-    
-    ```bash
-    npx checkly login
-    ```
-6. Run your checks in the Checkly cloud with the following commands:
-      
-    ```bash
-    npx checkly test --env-file "./.env" --record
-    ```
-    This will run the checks in the `__checks__` directory and record them in your Checkly account as [test session](https://www.checklyhq.com/docs/testing/#test-sessions). You can now see them in the [Checkly test sessions dashboard](https://app.checklyhq.com/test-sessions).
+Use the Checkly CLI to login, or [create an account](https://app.checklyhq.com/signup) if you don't already have one.
 
+```bash
+npx checkly login
+```
 
-7. To deploy your checks as monitors, run the following commands:
+We have a Vercel Production URL for our app, similar to `https://nextjs-checkly-starter-template-checkly.vercel.app`. Let's add this to our Checkly environment variables:
 
-    ```bash
-    npx checkly env add "PRODUCTION_URL" "<YOUR VERCEL PRODUCTION URL>"
-   ```
-    This command persists the `PRODUCTION_URL` to the Checkly cloud.
+```bash
+npx checkly env add "PRODUCTION_URL" "<your Vercel Production URL>"
+```
 
-    ```bash
-    npx checkly deploy
-    ```
-    This command deploys the checks in the `__checks__` directory as monitors in your Checkly account. You can now see them in the [Checkly home dashboard](https://app.checklyhq.com/).
+Now would be a good time to also add your Vercel Deployment Protection bypass secret, if you created one earlier:
 
+```bash
+npx checkly env add --secret "VERCEL_AUTOMATION_BYPASS_SECRET" "<secret>"
+```
 
-## 2. Running Checks before & after Deployment in CI
+We're ready to go! Let's run our checks in the `__checks__` directory in the Checkly cloud, and record them as a [test session](https://checklyhq.com/docs/testing/#test-sessions):
 
-You can run your Checkly checks right after any **Vercel Preview Deployment** and then deploy your checks as 
-monitors on Checkly. This is a powerful strategy to make sure your never ship critical breaking errors
-to **Production**, while at the same time surfacing any outages in your **Production Deployments**.
+```bash
+npx checkly test --record
+```
 
-### 2.2 Setting up GithHub Actions
+Check it out in the [Checkly test sessions dashboard](https://app.checklyhq.com/test-sessions).
 
-This example uses GitHub Actions. Check out the workflow in `.github/workflows/checkly.yml` but you can any other CI platform.
-We have [example configs for Jenkins and GitLab CI in our docs](https://www.checklyhq.com/docs/cicd/). 
+You can also deploy the checks as monitors:
 
+```bash
+npx checkly deploy
+```
 
-1. Create an API key [in the API keys section of your Checkly account](https://app.checklyhq.com/settings/user/api-keys)
-2. Take a note of your [Checkly Account ID in the General section of your Checkly account](https://app.checklyhq.com/settings/account/general) 
-3. Save your API key and Account ID as `CHECKLY_API_KEY` and `CHECKLY_ACCOUNT_ID` as **secrets** in your GitHub Actions configuration.
+Great! We're all set up with testing & monitoring our Production Deployments, which you can check out in the [Checkly home dashboard](https://app.checklyhq.com). Let's do the same for our Vercel Preview environment.
+
+### Running checks in CI
+
+You can run your Checkly checks right after any Vercel Preview Deployment, and then deploy your checks as monitors on Checkly. This is a powerful strategy to make sure your never ship breaking errors to Production, while at the same time surfacing any outages in your Production Deployments.
+
+This example uses GitHub Actions — check out the workflow in [`.github/workflows/checkly.yml`](/.github/workflows/checkly.yml) — but you can use any other CI platform. We have [example configs for Jenkins and GitLab CI in our docs](https://checklyhq.com/docs/cicd).
+
+1. Create an API key [in **User Settings > API keys**](https://app.checklyhq.com/settings/user/api-keys).
+2. Take note of your [Checkly Account ID in **Account Settings > General**](https://app.checklyhq.com/settings/account/general).
+3. Save your API key and Account ID as secrets named `CHECKLY_API_KEY` and `CHECKLY_ACCOUNT_ID` in your GitHub Actions configuration.
 
 ![GitHub Actions Secret Page](assets/gh_actions_secrets.png)
 
 Now, on every deployment webhook that GitHub receives from Vercel, the GitHub Actions workflow will run the checks in the `__checks__` directory.
 
-- A markdown formatted report will be posted as a comment in the GitHub Actions summary.
-- Preview Deployments are tested against the generated preview deployment URL and recorded as test sessions in Checkly.
-- Production Deployments are tested against the production URL and deployed as monitors in Checkly if all checks pass. 
+- A Markdown-formatted report will be posted as a comment in the GitHub Actions summary.
+- Preview Deployments are tested against the generated Preview Deployment URL, and recorded as test sessions in Checkly.
+- Production Deployments are tested against the Production URL, and deployed as monitors in Checkly if all checks pass.
 
-Links:
-- [Checkly docs on Test Sessions](https://www.checklyhq.com/docs/testing/#test-sessions)
-- [Checkly docs on GitHub Actions integration](https://www.checklyhq.com/docs/cicd/github-actions/)
-- [Vercel docs on running tests](https://vercel.com/guides/how-can-i-run-end-to-end-tests-after-my-vercel-preview-deployment)
-
-## Notes
-
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app)
-and edited where needed.
+That's it for this example! If you have questions or feedback, please drop us a note in our [Slack community](https://checklyhq.com/slack).
 
 ## Further reading
 
 - Official [Checkly integration from the Vercel Marketplace](https://vercel.com/integrations/checkly)
-- Checkly docs on [integrating Vercel with Checkly](https://www.checklyhq.com/docs/cicd/vercel)
+- Checkly docs on [integrating with Vercel](https://checklyhq.com/docs/cicd/vercel)
+- Checkly docs on [integrating with GitHub Actions](https://checklyhq.com/docs/cicd/github-actions)
+- Vercel docs on [running tests](https://vercel.com/guides/how-can-i-run-end-to-end-tests-after-my-vercel-preview-deployment)

--- a/README.md
+++ b/README.md
@@ -1,23 +1,51 @@
 # Next.js & Checkly Starter Template
 
-This repo showcases a simple Next.js app, hosted on Vercel, that uses Checkly to run checks before and after deployment in CI.
-It includes the following features:
+This repo showcases a simple Next.js app, hosted on Vercel, that uses Checkly to run checks before and after deployment in CI. It includes the following features:
+
 1. A Next.js app that fetches data from the `/api/greetings` endpoint and displays it on the landing page.
 2. Checkly checks in the `__checks__` directory verify if the page loads and if the API responds correctly.
 3. The necessary Checkly CLI and GitHub Actions configuration to run these checks in CI.
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fcheckly%2Fnextjs-checkly-starter-template)
 
-## Quickstart
+## Getting started
 
-1. Fork this repo or click the "Use this template" button in the top right corner.
-2. Clone the repo and run `npm install`.
+There are a couple ways to use this template:
 
-    ```bash
-    git clone https://github.com/checkly/nextjs-checkly-starter-template.git
-    cd nextjs-checkly-starter-template
-    npm i
-    ```
+- Forking the repo / clicking "Use this template" in the top right corner
+- Deploying the official [Vercel template](https://vercel.com/templates/Next.js/nextjs-checkly)
+
+Either way, get started by cloning your repo and installing dependencies:
+
+```bash
+git clone https://github.com/checkly/nextjs-checkly-starter-template.git # replace with your repo link
+cd nextjs-checkly-starter-template
+npm i
+```
+
+### Vercel Deployment Protection
+
+Before running our checks, let's make sure Vercel Deployment Protection is configured to work with Checkly. If you chose to fork or use the template on GitHub, go ahead and deploy your repo to Vercel [in the dashboard](https://vercel.com/new) or with the CLI:
+
+```bash
+vercel
+```
+
+By default, Vercel Preview Deployments are protected and only accessible by logged-in members of your Vercel team. We want to be able to access these from our Checkly checks as well. We can bypass Vercel Deployment Protection by either:
+
+- Enabling [Protection Bypass for Automation](https://vercel.com/docs/deployment-protection/methods-to-bypass-deployment-protection/protection-bypass-automation)
+- Disabling Vercel Deployment Protection altogether for this example repo
+
+![Disable Vercel Deployment Protection](assets/vercel_deployment_protection.png)
+
+If you choose to keep Deployment Protection on, ensure:
+
+1. The **Automatically expose [System Environment Variables](https://vercel.com/docs/environment-variables/system-environment-variables)** setting (in `Project Settings > Environment Variables`) is checked; and
+2. You create a `VERCEL_AUTOMATION_BYPASS_SECRET` in `Project Settings > Deployment Protection`. Our app will automatically use this for fetching from the `/api/greetings` endpoint.
+
+Redeploy after applying any changes to your project settings in Vercel. Each deployment will alert you of anything it's missing on the landing page.
+
+---
 
 3. Deploy the app to Vercel. You should now have a stable, production Vercel URL for your app similar to `https://nextjs-checkly-starter-template-checkly.vercel.app/`
 4. Copy and paste that URL into the `.env` file as the `PRODUCTION_URL` value, e.g.
@@ -58,19 +86,6 @@ You can run your Checkly checks right after any **Vercel Preview Deployment** an
 monitors on Checkly. This is a powerful strategy to make sure your never ship critical breaking errors
 to **Production**, while at the same time surfacing any outages in your **Production Deployments**.
 
-### 2.1 Bypassing Vercel Preview Deployment Protection
-
-By default, Vercel Preview Deployments are protected and only accessible by logged-in users. However, we want to access
-any Preview Deployment with our Playwright-powered Checkly checks. To do this, we need to bypass the protection. 
-
-For the sake of this example repo, you can just disable this protection in the **Settings / Deployment Protection** section
-in your Vercel project.
-
-![disable deployment protection](assets/vercel_deployment_protection.png)
-
-In a real-world scenario, you would create a [Vercel protection bypass token](https://www.checklyhq.com/docs/cicd/vercel-deployment-protection/) and use that in your Checkly scripts to 
-authenticate against the Preview Deployment.
-
 ### 2.2 Setting up GithHub Actions
 
 This example uses GitHub Actions. Check out the workflow in `.github/workflows/checkly.yml` but you can any other CI platform.
@@ -98,3 +113,8 @@ Links:
 
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app)
 and edited where needed.
+
+## Further reading
+
+- Official [Checkly integration from the Vercel Marketplace](https://vercel.com/integrations/checkly)
+- Checkly docs on [integrating Vercel with Checkly](https://www.checklyhq.com/docs/cicd/vercel)

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ You can run your Checkly checks right after any Vercel Preview Deployment, and t
 
 This example uses GitHub Actions — check out the workflow in [`.github/workflows/checkly.yml`](/.github/workflows/checkly.yml) — but you can use any other CI platform. We have [example configs for Jenkins and GitLab CI in our docs](https://checklyhq.com/docs/cicd).
 
-1. Create an API key [in **User Settings > API keys**](https://app.checklyhq.com/settings/user/api-keys).
-2. Take note of your [Checkly Account ID in **Account Settings > General**](https://app.checklyhq.com/settings/account/general).
+1. Create an API key in [**User Settings > API keys**](https://app.checklyhq.com/settings/user/api-keys).
+2. Take note of your Checkly Account ID in [**Account Settings > General**](https://app.checklyhq.com/settings/account/general).
 3. Save your API key and Account ID as secrets named `CHECKLY_API_KEY` and `CHECKLY_ACCOUNT_ID` in your GitHub Actions configuration.
 
 ![GitHub Actions Secret Page](assets/gh_actions_secrets.png)

--- a/__checks__/api.check.ts
+++ b/__checks__/api.check.ts
@@ -12,6 +12,9 @@ new ApiCheck("api-check-1", {
   request: {
     url: "{{BASE_URL}}/api/greetings",
     method: "GET",
+    headers: [
+      { key: "x-vercel-protection-bypass", value: "{{VERCEL_AUTOMATION_BYPASS_SECRET}}" }
+    ],
     assertions: [
       AssertionBuilder.statusCode().equals(200),
       AssertionBuilder.jsonBody("$[0].text").notEmpty()

--- a/__checks__/api.check.ts
+++ b/__checks__/api.check.ts
@@ -1,20 +1,20 @@
-import { ApiCheck, Frequency, AssertionBuilder, RetryStrategyBuilder } from 'checkly/constructs'
+import { ApiCheck, Frequency, AssertionBuilder, RetryStrategyBuilder } from "checkly/constructs"
 
-new ApiCheck('api-check-1', {
-  name: 'Greetings API',
+new ApiCheck("api-check-1", {
+  name: "Greetings API",
   frequency: Frequency.EVERY_1H,
-  tags: ['api'],
-  locations: ['us-east-1', 'us-west-1'],
+  tags: ["api"],
+  locations: ["us-east-1", "us-west-1"],
   runParallel: true,
   setupScript: {
-    content: "process.env.BASE_URL = process.env.ENVIRONMENT_URL || process.env.PRODUCTION_URL",
+    content: "process.env.BASE_URL = process.env.ENVIRONMENT_URL || process.env.PRODUCTION_URL"
   },
   request: {
-    url: '{{BASE_URL}}/api/greetings',
-    method: 'GET',
+    url: "{{BASE_URL}}/api/greetings",
+    method: "GET",
     assertions: [
       AssertionBuilder.statusCode().equals(200),
-      AssertionBuilder.jsonBody('$[0].text').notEmpty()
+      AssertionBuilder.jsonBody("$[0].text").notEmpty()
     ]
   },
   retryStrategy: RetryStrategyBuilder.exponentialStrategy({

--- a/__checks__/landing-page.check.ts
+++ b/__checks__/landing-page.check.ts
@@ -1,13 +1,13 @@
-import {BrowserCheck, Frequency, RetryStrategyBuilder} from "checkly/constructs";
+import {BrowserCheck, Frequency, RetryStrategyBuilder} from "checkly/constructs"
 
-new BrowserCheck('landing-page-check-1', {
-  name: 'Landing Page Check',
+new BrowserCheck("landing-page-check-1", {
+  name: "Landing Page Check",
   frequency: Frequency.EVERY_1H,
-  tags: ['web'],
-  locations: ['us-east-1', 'us-west-1'],
+  tags: ["web"],
+  locations: ["us-east-1", "us-west-1"],
   runParallel: true,
   code: {
-    entrypoint: './landing-page.spec.ts'
+    entrypoint: "./landing-page.spec.ts"
   },
   retryStrategy: RetryStrategyBuilder.exponentialStrategy({
     maxRetries: 3,

--- a/__checks__/landing-page.check.ts
+++ b/__checks__/landing-page.check.ts
@@ -9,13 +9,6 @@ new BrowserCheck("landing-page-check-1", {
   code: {
     entrypoint: "./landing-page.spec.ts"
   },
-  playwrightConfig: {
-    use: {
-      extraHTTPHeaders: {
-        "x-vercel-protection-bypass": process.env.VERCEL_AUTOMATION_BYPASS_SECRET || ""
-      }
-    }
-  },
   retryStrategy: RetryStrategyBuilder.exponentialStrategy({
     maxRetries: 3,
     baseBackoffSeconds: 1,

--- a/__checks__/landing-page.check.ts
+++ b/__checks__/landing-page.check.ts
@@ -9,6 +9,13 @@ new BrowserCheck("landing-page-check-1", {
   code: {
     entrypoint: "./landing-page.spec.ts"
   },
+  playwrightConfig: {
+    use: {
+      extraHTTPHeaders: {
+        "x-vercel-protection-bypass": process.env.VERCEL_AUTOMATION_BYPASS_SECRET || ""
+      }
+    }
+  },
   retryStrategy: RetryStrategyBuilder.exponentialStrategy({
     maxRetries: 3,
     baseBackoffSeconds: 1,

--- a/__checks__/landing-page.spec.ts
+++ b/__checks__/landing-page.spec.ts
@@ -2,11 +2,6 @@ import { test, expect } from "@playwright/test"
 
 test("Landing page", async ({ page }) => {
   const baseURL = process.env.ENVIRONMENT_URL! || process.env.PRODUCTION_URL!
-  test.use({
-    extraHTTPHeaders: {
-      "x-vercel-protection-bypass": process.env.VERCEL_AUTOMATION_BYPASS_SECRET || ""
-    }
-  })
   const response = await page.goto(baseURL)
   expect(response?.status()).toBeLessThan(400)
   await page.screenshot({ path: "test-results/screenshot/landing-page.jpg" })

--- a/__checks__/landing-page.spec.ts
+++ b/__checks__/landing-page.spec.ts
@@ -1,9 +1,9 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from "@playwright/test"
 
-test('Landing page', async ({ page }) => {
+test("Landing page", async ({ page }) => {
   const baseURL = process.env.ENVIRONMENT_URL! || process.env.PRODUCTION_URL!
   const response = await page.goto(baseURL)
   expect(response?.status()).toBeLessThan(400)
-  await page.screenshot({ path: 'test-results/screenshot/landing-page.jpg' })
-  await expect(page.getByText('Go to the GitHub repo')).toBeVisible()
+  await page.screenshot({ path: "test-results/screenshot/landing-page.jpg" })
+  await expect(page.getByText("Go to the GitHub repo")).toBeVisible()
 })

--- a/__checks__/landing-page.spec.ts
+++ b/__checks__/landing-page.spec.ts
@@ -2,6 +2,11 @@ import { test, expect } from "@playwright/test"
 
 test("Landing page", async ({ page }) => {
   const baseURL = process.env.ENVIRONMENT_URL! || process.env.PRODUCTION_URL!
+  test.use({
+    extraHTTPHeaders: {
+      "x-vercel-protection-bypass": process.env.VERCEL_AUTOMATION_BYPASS_SECRET || ""
+    }
+  })
   const response = await page.goto(baseURL)
   expect(response?.status()).toBeLessThan(400)
   await page.screenshot({ path: "test-results/screenshot/landing-page.jpg" })

--- a/__checks__/landing-page.spec.ts
+++ b/__checks__/landing-page.spec.ts
@@ -1,5 +1,11 @@
 import { test, expect } from "@playwright/test"
 
+test.use({
+  extraHTTPHeaders: {
+    "x-vercel-protection-bypass": process.env.VERCEL_AUTOMATION_BYPASS_SECRET || ""
+  }
+})
+
 test("Landing page", async ({ page }) => {
   const baseURL = process.env.ENVIRONMENT_URL! || process.env.PRODUCTION_URL!
   const response = await page.goto(baseURL)

--- a/checkly.config.ts
+++ b/checkly.config.ts
@@ -1,58 +1,58 @@
-import { defineConfig } from 'checkly'
+import { defineConfig } from "checkly"
 
 /**
  * See https://www.checklyhq.com/docs/cli/project-structure/
  */
 const config = defineConfig({
   /* A human friendly name for your project */
-  projectName: 'Next.js starter template',
+  projectName: "Next.js starter template",
   /** A logical ID that needs to be unique across your Checkly account,
    * See https://www.checklyhq.com/docs/cli/constructs/ to learn more about logical IDs.
    */
-  logicalId: 'nextjs-template-project',
+  logicalId: "nextjs-template-project",
   /* An optional URL to your Git repo */
-  repoUrl: 'https://github.com/checkly/nextjs-starter-template',
+  repoUrl: "https://github.com/checkly/nextjs-starter-template",
   /* Sets default values for Checks */
   checks: {
     /* A default for how often your Check should run in minutes */
     frequency: 10,
     /* Checkly data centers to run your Checks as monitors */
-    locations: ['us-east-1', 'us-west-1'],
+    locations: ["us-east-1", "us-west-1"],
     /* An optional array of tags to organize your Checks */
-    tags: ['nextjs'],
+    tags: ["nextjs"],
     /** The Checkly Runtime identifier, determining npm packages and the Node.js version available at runtime.
      * See https://www.checklyhq.com/docs/cli/npm-packages/
      */
-    runtimeId: '2024.09',
+    runtimeId: "2024.09",
     /* A glob pattern that matches the Checks inside your repo, see https://www.checklyhq.com/docs/cli/using-check-test-match/ */
-    checkMatch: '**/__checks__/**/*.check.ts',
+    checkMatch: "**/__checks__/**/*.check.ts",
     /* Global configuration option for Playwright-powered checks. See https://www.checklyhq.com/docs/browser-checks/playwright-test/#global-configuration */
     playwrightConfig: {
       use: {
         viewport: {
           width: 1920,
-          height: 1080,
+          height: 1080
         }
       },
       expect: {
-        timeout: 10000,
+        timeout: 10000
       }
     },
     browserChecks: {
       /* A glob pattern matches any Playwright .spec.ts files and automagically creates a Browser Check. This way, you
       * can just write native Playwright code. See https://www.checklyhq.com/docs/cli/using-check-test-match/
       * */
-      testMatch: '**/__checks__/**/*.spec.ts',
-    },
+      testMatch: "**/__checks__/**/*.spec.ts"
+    }
   },
   cli: {
     /* The default datacenter location to use when running npx checkly test */
-    runLocation: 'us-east-1',
+    runLocation: "us-east-1",
     /* An array of default reporters to use when a reporter is not specified with the "--reporter" flag */
-    reporters: ['list'],
+    reporters: ["list"],
     /* How many times to retry a failing test run when running `npx checkly test` or `npx checkly trigger` (max. 3) */
-    retries: 0,
-  },
+    retries: 0
+  }
 })
 
 export default config

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from "next"
 
 const nextConfig: NextConfig = {
   /* config options here */
-};
+}
 
-export default nextConfig;
+export default nextConfig

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,8 +1,8 @@
-/** @type {import('postcss-load-config').Config} */
+/** @type {import("postcss-load-config").Config} */
 const config = {
   plugins: {
-    tailwindcss: {},
-  },
-};
+    tailwindcss: {}
+  }
+}
 
-export default config;
+export default config

--- a/src/app/api/greetings/route.js
+++ b/src/app/api/greetings/route.js
@@ -1,11 +1,11 @@
 export async function GET() {
   return Response.json(
       [
-          { id: 1, text: 'Hello' },
-          { id: 2, text: 'Hallo' },
-          { id: 3, text: 'Hola' },
-          { id: 4, text: 'Ciao' },
-          { id: 5, text: 'こんにちは' }
+          { id: 1, text: "Hello" },
+          { id: 2, text: "Hallo" },
+          { id: 3, text: "Hola" },
+          { id: 4, text: "Ciao" },
+          { id: 5, text: "こんにちは" }
       ]
   )
 }

--- a/src/app/api/greetings/route.ts
+++ b/src/app/api/greetings/route.ts
@@ -1,3 +1,8 @@
+export type Greeting = {
+  id: number
+  text: string
+}
+
 export async function GET() {
   return Response.json(
       [

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,29 +1,27 @@
-import type { Metadata } from "next";
-import { Inter } from 'next/font/google'
-import "./globals.css";
+import type { Metadata } from "next"
+import { Inter } from "next/font/google"
+import "./globals.css"
 
 const inter = Inter({
-  subsets: ['latin'],
-  display: 'swap',
-});
+  subsets: ["latin"],
+  display: "swap"
+})
 
 export const metadata: Metadata = {
-  title: "Next / Checkly Starter Template",
-  description: "A simple Next app with a Checkly integration",
-};
+  title: "Next.js & Checkly Starter Template",
+  description: "A simple Next.js app with a Checkly integration"
+}
 
 export default function RootLayout({
-  children,
+  children
 }: Readonly<{
-  children: React.ReactNode;
+  children: React.ReactNode
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${inter.className} antialiased`}
-      >
+      <body className={`${inter.className} antialiased`}>
         {children}
       </body>
     </html>
-  );
+  )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,18 +1,18 @@
-import Link from "next/link";
-import Image from "next/image";
-import { headers } from 'next/headers';
+import Link from "next/link"
+import Image from "next/image"
+import { headers } from "next/headers"
 
 const VERCEL_PROTECTION_HEADER = "x-vercel-protection-bypass"
 
 export default async function Home({
-  searchParams,
+  searchParams
 }: {
   searchParams: Promise<URLSearchParams>
 }) {
   // construct the current server URL
   const headersList = await headers()
-  const host = headersList.get('host')
-  const proto = headersList.get('x-forwarded-proto')
+  const host = headersList.get("host")
+  const proto = headersList.get("x-forwarded-proto")
   const vercelProtection = headersList.get(VERCEL_PROTECTION_HEADER)
   const params = new URLSearchParams(await searchParams)
   const protection = (() => {
@@ -24,13 +24,13 @@ export default async function Home({
     }
 
     return null
-  })();
+  })()
   const apiURL = `${proto}://${host}/api/greetings`
 
   const response = await fetch(apiURL, {
     ...(protection
       ? { headers: { [VERCEL_PROTECTION_HEADER]: protection } }
-      : {}),
+      : {})
   })
   const greetings = await response.json()
   // select random entry in greetings array
@@ -122,5 +122,5 @@ export default async function Home({
         </Link>
       </footer>
     </div>
-  );
+  )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,6 +34,7 @@ export default async function Home({
   const greetings = await response.json()
   // select random entry in greetings array
   const greeting = greetings[Math.floor(Math.random() * greetings.length)]
+
   return (
     <div className="grid grid-rows-[20px_1fr_20px] justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
       <main className="flex flex-col gap-8 row-start-2 items-center sm:items-start">
@@ -47,10 +48,10 @@ export default async function Home({
             className="mb-4"
           />
           </a>
-          <div className="text-gray-300 mb-4">
+          <div className="mb-4 text-gray-500 dark:text-gray-400">
             <span className="capitalize">{greeting.text}</span>, this is the
           </div>
-          <h1 className="text-4xl text-left sm:text-5xl font-bold text-white">
+          <h1 className="text-4xl text-left sm:text-5xl font-bold">
             Next.js & Checkly starter template
           </h1>
         </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,36 +36,27 @@ export default async function Home({
   // select random entry in greetings array
   const greeting = greetings[Math.floor(Math.random() * greetings.length)]
 
-  return (
-    <div className="grid grid-rows-[20px_1fr_20px] justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-8 row-start-2 items-center sm:items-start">
-        <div>
-          <Link href="https://checklyhq.com" target="_blank">
-          <Image
-            src="https://www.checklyhq.com/images/racoon_logo.svg"
-            alt="Checkly logomark"
-            width={40}
-            height={40}
-            className="mb-4"
-          />
-          </Link>
-          <div className="mb-4 text-gray-500 dark:text-gray-400">
-            <span className="capitalize">{greeting.text}</span>, this is the
-          </div>
-          <h1 className="text-4xl text-left sm:text-5xl font-bold">
-            Next.js & Checkly starter template
-          </h1>
-        </div>
+  function Greeting() {
+    return (
+      <div className="mb-4 text-gray-500 dark:text-gray-400">
+        <span className="capitalize">{greeting.text}</span>, this is the
+      </div>
+    )
+  }
+
+  function Success() {
+    return (
+      <>
         <p>
           This is a simple Next.js app with a Checkly integration. In a nutshell, it does three things:
         </p>
         <ol className="list-decimal text-left list-inside">
           <li className="mb-2">
-            The app fetches data from the
+            The app fetches data from the {" "}
             <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-semibold">
               /api/greetings
             </code>
-            endpoint and displays it on this landing page.
+            {" "} endpoint and displays it on this landing page.
           </li>
           <li className="mb-2">
             Checkly verifies if the page loads — using Playwright — and if the API responds correctly.
@@ -75,15 +66,15 @@ export default async function Home({
           </li>
         </ol>
         <p>
-          To get going,
+          To get going, {" "}
           <Link
-            className="text-blue-700 underline"
+            className="text-blue-700 dark:text-blue-500 underline"
             href="https://github.com/checkly/nextjs-checkly-starter-template"
             target="_blank"
           >
             go to the repo
           </Link>
-          and follow the instructions in the README.md file.
+          {" "} and follow the instructions in the README.md file.
         </p>
         <div className="flex gap-4 items-center flex-col sm:flex-row">
           <Link
@@ -95,6 +86,29 @@ export default async function Home({
             Go to the GitHub repo
           </Link>
         </div>
+      </>
+    )
+  }
+
+  return (
+    <div className="grid grid-rows-[20px_1fr_20px] justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
+      <main className="flex flex-col gap-8 row-start-2 items-center sm:items-start">
+        <div>
+          <Link href="https://checklyhq.com" target="_blank">
+            <Image
+              src="https://www.checklyhq.com/images/racoon_logo.svg"
+              alt="Checkly logomark"
+              width={40}
+              height={40}
+              className="mb-4"
+            />
+          </Link>
+          <Greeting />
+          <h1 className="text-4xl text-left sm:text-5xl font-bold">
+            Next.js & Checkly starter template
+          </h1>
+        </div>
+        <Success />
       </main>
       <footer className="row-start-3 flex gap-6 flex-wrap items-center justify-center">
         <Link

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import Image from "next/image";
 import { headers } from 'next/headers';
 
@@ -39,7 +40,7 @@ export default async function Home({
     <div className="grid grid-rows-[20px_1fr_20px] justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
       <main className="flex flex-col gap-8 row-start-2 items-center sm:items-start">
         <div>
-          <a href="https://checklyhq.com" target="_blank">
+          <Link href="https://checklyhq.com" target="_blank">
           <Image
             src="https://www.checklyhq.com/images/racoon_logo.svg"
             alt="Checkly logomark"
@@ -47,7 +48,7 @@ export default async function Home({
             height={40}
             className="mb-4"
           />
-          </a>
+          </Link>
           <div className="mb-4 text-gray-500 dark:text-gray-400">
             <span className="capitalize">{greeting.text}</span>, this is the
           </div>
@@ -59,34 +60,52 @@ export default async function Home({
           This is a simple Next.js app with a Checkly integration. In a nutshell, it does three things:
         </p>
         <ol className="list-decimal text-left list-inside">
-          <li className="mb-2">The app fetches data from the <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-semibold">/api/greetings</code> endpoint and displays it on this landing
-            page.
+          <li className="mb-2">
+            The app fetches data from the
+            <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-semibold">
+              /api/greetings
+            </code>
+            endpoint and displays it on this landing page.
           </li>
-          <li className="mb-2">Checkly verifies if the page loads — using Playwright — and if the API responds correctly.</li>
-          <li>Checkly checks can run after deployment and deployed as monitors using the Checkly CLI.</li>
+          <li className="mb-2">
+            Checkly verifies if the page loads — using Playwright — and if the API responds correctly.
+          </li>
+          <li>
+            Checkly checks can run after deployment and deployed as monitors using the Checkly CLI.
+          </li>
         </ol>
-        <p>To get going, <a className="text-blue-700 underline" href="https://github.com/checkly/nextjs-checkly-starter-template" target="_blank">go to the repo</a> and follow the instructions in the README.md file.</p>
+        <p>
+          To get going,
+          <Link
+            className="text-blue-700 underline"
+            href="https://github.com/checkly/nextjs-checkly-starter-template"
+            target="_blank"
+          >
+            go to the repo
+          </Link>
+          and follow the instructions in the README.md file.
+        </p>
         <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
+          <Link
             className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5"
             href="https://github.com/checkly/nextjs-checkly-starter-template"
             target="_blank"
             rel="noopener noreferrer"
           >
             Go to the GitHub repo
-          </a>
+          </Link>
         </div>
       </main>
       <footer className="row-start-3 flex gap-6 flex-wrap items-center justify-center">
-        <a
+        <Link
           className="flex items-center gap-2 hover:underline hover:underline-offset-4"
           href="https://github.com/checkly/nextjs-checkly-starter-template"
           target="_blank"
           rel="noopener noreferrer"
         >
           GitHub Repo
-        </a>
-        <a
+        </Link>
+        <Link
           className="flex items-center gap-2 hover:underline hover:underline-offset-4"
           href="https://checklyhq.com"
           target="_blank"
@@ -100,7 +119,7 @@ export default async function Home({
             height={16}
           />
           Go to checklyhq.com →
-        </a>
+        </Link>
       </footer>
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -44,6 +44,24 @@ export default async function Home({
     )
   }
 
+  function SystemEnvVarsNotExposed() {
+    return (
+      <>
+        <p className="border border-solid border-blue-500 dark:border-blue-400 rounded-md p-4 text-blue-500 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/20">
+          Almost there! Please check the README for instructions on how to expose your {" "}
+          <Link
+            className="text-blue-700 dark:text-blue-500 underline"
+            href="https://vercel.com/docs/environment-variables/system-environment-variables"
+            target="_blank"
+          >
+            Vercel system environment variables
+          </Link>
+          .
+        </p>
+      </>
+    )
+  }
+
   function Success() {
     return (
       <>
@@ -109,6 +127,14 @@ export default async function Home({
           </h1>
         </div>
         <Success />
+
+        {
+          // Warn if Vercel deployment does not have access to system environment variables
+          // See: https://vercel.com/docs/environment-variables/system-environment-variables
+          (process.env.NODE_ENV === "production" && !process.env.VERCEL)
+            && <SystemEnvVarsNotExposed />
+        }
+
       </main>
       <footer className="row-start-3 flex gap-6 flex-wrap items-center justify-center">
         <Link

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,18 +1,18 @@
-import type { Config } from "tailwindcss";
+import type { Config } from "tailwindcss"
 
 export default {
   content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}"
   ],
   theme: {
     extend: {
       colors: {
         background: "var(--background)",
-        foreground: "var(--foreground)",
-      },
-    },
+        foreground: "var(--foreground)"
+      }
+    }
   },
-  plugins: [],
-} satisfies Config;
+  plugins: []
+} satisfies Config


### PR DESCRIPTION
Hey friends! Edward here with the Vercel templates team :)

Thanks so much for the submission! There were a couple DX snags with this example that I wanted to share and hopefully ship a fix for. Here's what I found:

### Vercel Deployment Protection

The main issue was that the template would deploy successfully, but any Preview Deployment URL for users with Vercel Deployment Protection enabled would crash. This was due to an uncaught error from the `response.json()` call to the `/api/greetings` endpoint, which is authwalled.

<img width="1850" alt="image" src="https://github.com/user-attachments/assets/5186158f-a45b-4da8-94fd-0f0f0a11b99b" />

The README includes info on disabling Vercel Deployment Protection, but a nontrivial amount of Vercel users have this on by default, so I felt we should design accordingly.

This PR:

- Adds error handling to catch failed `greeting` rendering attempts
- In addition to headers and query parameters, checks for a `VERCEL_AUTOMATION_BYPASS_SECRET` environment variable, which is available after secret creation if the user has [System Environment Variables](https://vercel.com/docs/environment-variables/system-environment-variables) exposed to their deployments
- Adds info UI for when:
  - Vercel Deployment Protection is enabled, but we can't find a bypass
  - System Environment Variables aren't exposed to deployments
- Adds README documentation for addressing the two cases

<img width="926" alt="image" src="https://github.com/user-attachments/assets/9bd4e476-a84d-4df5-9641-8f7fc7a7e735" />

<img width="934" alt="image" src="https://github.com/user-attachments/assets/9bf0fa77-d083-4bde-bfe4-ea6451cbd4b7" />

### Checkly setup

To integrate Checkly checks with Vercel Deployment Protection, I followed the [suggestion from the docs](https://checklyhq.com/docs/cicd/vercel-deployment-protection) to pass the bypass secret as an environment variable. However, the example uses a checked-in `.env` to expose the `PRODUCTION_URL` to Checkly. This introduces a risk to users of their bypass secrets getting leaked.

Instead, this PR:

- Removes and gitignores `.env`
- Adds documentation on using `checkly env add` to get both the `PRODUCTION_URL` and `VERCEL_AUTOMATION_BYPASS_SECRET` into Checkly *(great CLI btw!)*
- Adds headers for both the API and browser check to use the bypass secret env var from Checkly

I also added a link to what *will be* the official template listing on Vercel once we get it shipped. Plus a few formatting nits for consistency — feel free to modify or bikeshed to preference 😝

Thanks y'all, happy to jam together or change as needed. Hope this helps! Let me know what you think, and feel free to reach out privately on X if preferable.

All the best,
Edward Shturman ([@edwardshturman](https://x.com/edwardshturman))
Content at Vercel ▲